### PR TITLE
Fix login logging to include payload only

### DIFF
--- a/resource/server.js
+++ b/resource/server.js
@@ -86,7 +86,7 @@ function auth(req, res, next) {
 app.post('/login', (req, res) => {
   const { user_id } = req.body;
   if (!user_id) return res.status(400).json({ error: 'user_id is required' });
-  const payload = { user_id, iat: Date.now() };  writeLog({ userId: user_id, endpoint: '/login', token, label: 'normal' });
+  const payload = { user_id, iat: Date.now() };
   const token = jwt.sign(payload, SECRET, { expiresIn: '1h' });
   writeLog({ userId: user_id, endpoint: '/login', payload, label: 'normal' });
   res.json({ token });


### PR DESCRIPTION
## Summary
- avoid logging JWT token in `/login` route
- log only the payload after JWT creation

## Testing
- `node resource/server.js`

------
https://chatgpt.com/codex/tasks/task_e_6856cd516c288327b9405ceb0602ff5e