### PR TITLE
Add randomness for log generation

### DIFF
--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -23,6 +23,7 @@ fs.writeFileSync(LOG_FILE, 'timestamp,user_id,endpoint,use_case,type,jwt,label\n
 
 const api = axios.create({ baseURL: 'http://localhost:3000', timeout: 5000 });
 const sleep = ms => new Promise(res => setTimeout(res, ms));
+const rand = arr => arr[Math.floor(Math.random() * arr.length)];
 function extractPayload(token) {
   try {
     const payloadPart = token.split('.')[1];
@@ -90,7 +91,7 @@ const scenarios = [invalidTokenSequence, noTokenSequence, reversedSequence];
   console.log(`▶ 異常系列 ${total} 本 生成開始`);
 
   for (let i = 0; i < total; i++) {
-    const scen = scenarios[i % scenarios.length];
+    const scen = rand(scenarios);
     await scen(`abuser${i + 1}`);
     await sleep(delay);
   }

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -26,6 +26,7 @@ fs.writeFileSync(LOG_FILE, 'timestamp,user_id,endpoint,use_case,type,jwt,label\n
 // ── 共通ユーティリティ ────────────────────────
 const api = axios.create({ baseURL: 'http://localhost:3000', timeout: 5000 });
 const sleep = ms => new Promise(res => setTimeout(res, ms));
+const randInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 function extractPayload(token) {
   try {
     const payloadPart = token.split('.')[1];
@@ -58,15 +59,21 @@ async function normalSequence(userId) {
   logRow({ ts: t0, userId, endpoint: '/login', token, label: 'normal' });
   const auth = { headers: { Authorization: `Bearer ${token}` } };
 
-  // 2. browse
-  const t1 = new Date().toISOString();
-  await api.get('/browse', auth);
-  logRow({ ts: t1, userId, endpoint: '/browse', token, label: 'normal' });
+  // 2. browse を 1~3 回ランダム実行
+  const browseCount = randInt(1, 3);
+  for (let i = 0; i < browseCount; i++) {
+    const t = new Date().toISOString();
+    await api.get('/browse', auth);
+    logRow({ ts: t, userId, endpoint: '/browse', token, label: 'normal' });
+  }
 
-  // 3. edit
-  const t2 = new Date().toISOString();
-  await api.post('/edit', {}, auth);
-  logRow({ ts: t2, userId, endpoint: '/edit', token, label: 'normal' });
+  // 3. edit を 0~2 回ランダム実行
+  const editCount = randInt(0, 2);
+  for (let i = 0; i < editCount; i++) {
+    const t = new Date().toISOString();
+    await api.post('/edit', {}, auth);
+    logRow({ ts: t, userId, endpoint: '/edit', token, label: 'normal' });
+  }
 
   // 4. logout
   const t3 = new Date().toISOString();


### PR DESCRIPTION
## Summary
- improve normal log generator with random browse/edit counts
- choose abnormal log scenarios at random

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856ecf04d208327ad45900753e7a1f2