### PR TITLE
Fix CSV column consistency

### DIFF
--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -23,7 +23,7 @@ const MAP = {
 if (!fs.existsSync(path.dirname(LOG_FILE))) fs.mkdirSync(path.dirname(LOG_FILE));
   fs.writeFileSync(
     LOG_FILE,
-    'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt,label\n'
+    'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt_payload,label\n'
   );
 
 const api = axios.create({ baseURL: 'http://localhost:3000', timeout: 5000 });
@@ -41,7 +41,8 @@ function extractPayload(token) {
   try {
     const payloadPart = token.split('.')[1];
     const json = Buffer.from(payloadPart, 'base64url').toString();
-    return JSON.stringify(JSON.parse(json));
+    const obj  = JSON.parse(json);
+    return Buffer.from(JSON.stringify(obj)).toString('base64url');
   } catch (_) {
     return 'invalid';
   }

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -23,7 +23,7 @@ const MAP = {
 if (!fs.existsSync(path.dirname(LOG_FILE))) fs.mkdirSync(path.dirname(LOG_FILE));
 fs.writeFileSync(
   LOG_FILE,
-  'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt,label\n'
+  'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt_payload,label\n'
 );
 
 // ── 共通ユーティリティ ────────────────────────
@@ -37,7 +37,8 @@ function extractPayload(token) {
   try {
     const payloadPart = token.split('.')[1];
     const json = Buffer.from(payloadPart, 'base64url').toString();
-    return JSON.stringify(JSON.parse(json));
+    const obj  = JSON.parse(json);
+    return Buffer.from(JSON.stringify(obj)).toString('base64url');
   } catch (_) {
     return 'invalid';
   }


### PR DESCRIPTION
## Summary
- keep CSV logs at a constant number of columns
- base64url-encode JWT payloads in normal/abnormal loggers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858277899988327b6dee2a1c61d12b8