### PR TITLE
Refactor operation logs

### DIFF
--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -10,6 +10,7 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 const jwt = require('jsonwebtoken');
+const updateOperationLog = require('./update_operation_log');
 const SECRET = 'change_this_to_env_secret';
 const LOG_FILE = path.join(__dirname, 'logs', 'abnormal_log.csv');
 
@@ -217,4 +218,5 @@ const scenarios = [
     await sleep(delay);
   }
   console.log(`完了：logs/abnormal_log.csv に保存済`);
+  updateOperationLog();
 })();

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -9,6 +9,7 @@
 const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
+const updateOperationLog = require('./update_operation_log');
 const LOG_FILE = path.join(__dirname, 'logs', 'normal_log.csv');
 
 // ── マッピング（endpoint → use_case/type） ──────────────
@@ -235,4 +236,5 @@ async function normalSequence(userId) {
     await sleep(delay);
   }
   console.log(`完了：logs/normal_log.csv に保存済`);
+  updateOperationLog();
 })();

--- a/resource/operation_log_summary.js
+++ b/resource/operation_log_summary.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_FILE = path.join(__dirname, 'logs', 'operation_log.csv');
+if (!fs.existsSync(LOG_FILE)) {
+  console.error('operation_log.csv not found');
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(LOG_FILE, 'utf8').trim().split('\n');
+if (lines.length <= 1) {
+  console.log('ログがありません');
+  process.exit(0);
+}
+
+console.log('行,日時,正常累計,異常累計,総数');
+lines.slice(1).forEach((line, idx) => {
+  console.log(`${idx + 1},${line}`);
+});
+
+const last = lines[lines.length - 1].split(',');
+console.log('\n--- 最新集計 ---');
+console.log(`正常: ${last[1]}`);
+console.log(`異常: ${last[2]}`);
+console.log(`総数: ${last[3]}`);

--- a/resource/server.js
+++ b/resource/server.js
@@ -16,7 +16,8 @@ const { extractPayload } = require('./jwt_helper');
 const SECRET   = 'change_this_to_env_secret'; // 本運用では環境変数へ
 const PORT     = 3000;
 const LOG_DIR  = path.join(__dirname, 'logs');
-const LOG_FILE = path.join(LOG_DIR, 'operation_log.csv');
+// 各リクエストの詳細ログは request_log.csv に保存
+const REQUEST_LOG = path.join(LOG_DIR, 'request_log.csv');
 
 // ── 1. 抽象化マッピングテーブル ─────────────────────────
 //   endpoint        → use_case (レイヤ2) → type (レイヤ3)
@@ -35,8 +36,8 @@ const getClientIP = req => (req.headers['x-forwarded-for'] || req.ip)
 
 // ── 2. ログファイル準備 ───────────────────────────────
 if (!fs.existsSync(LOG_DIR))  fs.mkdirSync(LOG_DIR);
-if (!fs.existsSync(LOG_FILE)) fs.writeFileSync(
-  LOG_FILE,
+if (!fs.existsSync(REQUEST_LOG)) fs.writeFileSync(
+  REQUEST_LOG,
   'timestamp,user_id,endpoint,use_case,type,ip,jwt_payload,label\n',
   'utf8'
 );
@@ -63,7 +64,7 @@ function writeLog({
     label
   ].join(',') + '\n';
 
-  fs.appendFile(LOG_FILE, line, err => {
+  fs.appendFile(REQUEST_LOG, line, err => {
     if (err) console.error('Log write error:', err);
   });
 }

--- a/resource/update_operation_log.js
+++ b/resource/update_operation_log.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_DIR = path.join(__dirname, 'logs');
+const NORMAL_FILE = path.join(LOG_DIR, 'normal_log.csv');
+const ABNORMAL_FILE = path.join(LOG_DIR, 'abnormal_log.csv');
+const OP_FILE = path.join(LOG_DIR, 'operation_log.csv');
+
+function countLines(file) {
+  if (!fs.existsSync(file)) return 0;
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  return lines.length > 1 ? lines.length - 1 : 0; // exclude header
+}
+
+function updateOperationLog() {
+  if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR);
+  const normalCount = countLines(NORMAL_FILE);
+  const abnormalCount = countLines(ABNORMAL_FILE);
+  const total = normalCount + abnormalCount;
+
+  const header = 'timestamp,normal_count,abnormal_count,total\n';
+  if (!fs.existsSync(OP_FILE)) {
+    fs.writeFileSync(OP_FILE, header);
+  }
+
+  const line = `${new Date().toISOString()},${normalCount},${abnormalCount},${total}\n`;
+  fs.appendFileSync(OP_FILE, line);
+}
+
+if (require.main === module) {
+  updateOperationLog();
+}
+
+module.exports = updateOperationLog;


### PR DESCRIPTION
## Summary
- log request details to `request_log.csv`
- compute cumulative counts via new `update_operation_log.js`
- call update script from normal and abnormal loggers
- simplify `operation_log_summary.js` to print summary lines

## Testing
- `npm test`
- `node resource/update_operation_log.js`


------
https://chatgpt.com/codex/tasks/task_e_685832b7fc20832786dbce223e11e84f