### PR TITLE
Enable npm test to run server and attack script

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -1,46 +1,34 @@
 import requests
-import subprocess
-import time
 import os
-
-SERVER_PATH = os.path.join('resource', 'server.js')
-
-server = subprocess.Popen(['node', SERVER_PATH])
-# wait for server to start
-time.sleep(1)
 
 base = 'http://localhost:3000'
 
+# normal login to get token
+resp = requests.post(f'{base}/login', json={'user_id': 'attacker'})
+resp.raise_for_status()
+token = resp.json().get('token')
+
+# invalid token attack
+bad_token = token[:-1] + 'x'
+headers_bad = {'Authorization': f'Bearer {bad_token}'}
 try:
-    # normal login to get token
-    resp = requests.post(f'{base}/login', json={'user_id': 'attacker'})
-    resp.raise_for_status()
-    token = resp.json().get('token')
+    requests.get(f'{base}/browse', headers=headers_bad)
+except requests.RequestException:
+    pass
 
-    # invalid token attack
-    bad_token = token[:-1] + 'x'
-    headers_bad = {'Authorization': f'Bearer {bad_token}'}
-    try:
-        requests.get(f'{base}/browse', headers=headers_bad)
-    except requests.RequestException:
-        pass
+# request nonexistent endpoint
+headers = {'Authorization': f'Bearer {token}'}
+try:
+    requests.get(f'{base}/admin', headers=headers)
+except requests.RequestException:
+    pass
 
-    # request nonexistent endpoint
-    headers = {'Authorization': f'Bearer {token}'}
-    try:
-        requests.get(f'{base}/admin', headers=headers)
-    except requests.RequestException:
-        pass
-
-    # logout and reuse token
-    requests.post(f'{base}/logout', headers=headers)
-    try:
-        requests.get(f'{base}/browse', headers=headers)
-    except requests.RequestException:
-        pass
-finally:
-    server.terminate()
-    server.wait()
+# logout and reuse token
+requests.post(f'{base}/logout', headers=headers)
+try:
+    requests.get(f'{base}/browse', headers=headers)
+except requests.RequestException:
+    pass
 
 log_file = os.path.join('resource', 'logs', 'request_log.csv')
 if os.path.exists(log_file):

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "uuid": "^11.1.0"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "node run.js"
   },
   "devDependencies": {
     "puppeteer": "^24.10.2"

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,10 @@ npm install
 pip install -r requirements.txt
 ```
 
-Run the attack sequence:
+Run the attack sequence using npm:
 
 ```bash
-python3 attack_patterns.py
+npm test
 ```
 
 Log output is written to `resource/logs/request_log.csv`.

--- a/run.js
+++ b/run.js
@@ -1,0 +1,15 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+const pythonCmd = process.platform === 'win32' ? 'py' : 'python';
+
+const server = spawn('node', [path.join('resource', 'server.js')], {
+  stdio: 'inherit'
+});
+
+const attack = spawn(pythonCmd, ['attack.py'], { stdio: 'inherit' });
+
+attack.on('exit', code => {
+  server.kill();
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- run the attack against the sample server via `npm test`
- start the server and attack script from `run.js`
- adjust `attack.py` to assume server is already running
- update README instructions

## Testing
- `pip install -r requirements.txt`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bfc9d542883278f23b1fe29ac0395