### PR TITLE
Add --h option to control log output

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -1,5 +1,11 @@
+import argparse
 import requests
 import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--h', type=int, default=10,
+                    help='表示するログ行数')
+args = parser.parse_args()
 
 base = 'http://localhost:3000'
 
@@ -33,7 +39,7 @@ except requests.RequestException:
 log_file = os.path.join('resource', 'logs', 'request_log.csv')
 if os.path.exists(log_file):
     with open(log_file, 'r') as f:
-        lines = f.readlines()[-10:]
+        lines = f.readlines()[-args.h:]
         print(''.join(lines))
 else:
     print('Log file not found')

--- a/attack_patterns.py
+++ b/attack_patterns.py
@@ -1,3 +1,4 @@
+import argparse
 import requests
 import subprocess
 import time
@@ -8,6 +9,11 @@ import jwt
 
 SERVER_PATH = os.path.join('resource', 'server.js')
 SECRET = 'change_this_to_env_secret'
+parser = argparse.ArgumentParser()
+parser.add_argument('--h', type=int, default=20,
+                    help='表示するログ行数')
+args = parser.parse_args()
+
 BASE = 'http://localhost:3000'
 
 def start_server():
@@ -132,7 +138,7 @@ def main():
     finally:
         server.terminate()
         server.wait()
-        print_log()
+        print_log(args.h)
 
 if __name__ == '__main__':
     main()

--- a/normal.py
+++ b/normal.py
@@ -1,6 +1,12 @@
+import argparse
 import requests
 import time
 import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--h', type=int, default=10,
+                    help='表示するログ行数')
+args = parser.parse_args()
 
 BASE = 'http://localhost:3000'
 
@@ -22,7 +28,7 @@ def main():
     log_file = os.path.join('resource', 'logs', 'request_log.csv')
     if os.path.exists(log_file):
         with open(log_file, 'r') as f:
-            lines = f.readlines()[-10:]
+            lines = f.readlines()[-args.h:]
             print(''.join(lines))
     else:
         print('Log file not found')


### PR DESCRIPTION
## Summary
- allow specifying log display count with `--h` in Python utilities
- show `--h` parameter output in log viewer scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c0192deb48327846edee53a7d889d