### PR TITLE
Enhance log processing

### DIFF
--- a/resource/operation_log_summary.js
+++ b/resource/operation_log_summary.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const readline = require('readline');
 
 const LOG_FILE = path.join(__dirname, 'logs', 'operation_log.csv');
 if (!fs.existsSync(LOG_FILE)) {
@@ -7,19 +8,31 @@ if (!fs.existsSync(LOG_FILE)) {
   process.exit(1);
 }
 
-const lines = fs.readFileSync(LOG_FILE, 'utf8').trim().split('\n');
-if (lines.length <= 1) {
-  console.log('ログがありません');
-  process.exit(0);
+async function readLines(file) {
+  const arr = [];
+  const rl = readline.createInterface({
+    input: fs.createReadStream(file),
+    crlfDelay: Infinity
+  });
+  for await (const line of rl) arr.push(line);
+  return arr;
 }
 
-console.log('行,日時,正常累計,異常累計,総数');
-lines.slice(1).forEach((line, idx) => {
-  console.log(`${idx + 1},${line}`);
-});
+(async () => {
+  const lines = await readLines(LOG_FILE);
+  if (lines.length <= 1) {
+    console.log('ログがありません');
+    process.exit(0);
+  }
 
-const last = lines[lines.length - 1].split(',');
-console.log('\n--- 最新集計 ---');
-console.log(`正常: ${last[1]}`);
-console.log(`異常: ${last[2]}`);
-console.log(`総数: ${last[3]}`);
+  console.log('行,日時,正常累計,異常累計,総数');
+  lines.slice(1).forEach((line, idx) => {
+    console.log(`${idx + 1},${line}`);
+  });
+
+  const last = lines[lines.length - 1].split(',');
+  console.log('\n--- 最新集計 ---');
+  console.log(`正常: ${last[1]}`);
+  console.log(`異常: ${last[2]}`);
+  console.log(`総数: ${last[3]}`);
+})();


### PR DESCRIPTION
## Summary
- async tailing and per-user sorting in `attack_patterns.py`
- stream log counts in `update_operation_log.js`
- stream log summary in `operation_log_summary.js`
- add chunked log API in server
- stream scenario reading in capture controller

## Testing
- `pip install -r requirements.txt`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c11f3957c8327991504a572f7b1d5