### PR TITLE
Add profile and search endpoints with scenarios

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -14,6 +14,12 @@ resp = requests.post(f'{base}/login', json={'user_id': 'attacker'})
 resp.raise_for_status()
 token = resp.json().get('token')
 
+# use new endpoints
+headers = {'Authorization': f'Bearer {token}'}
+requests.get(f'{base}/profile', headers=headers)
+requests.post(f'{base}/profile', json={'bio': 'hi'}, headers=headers)
+requests.get(f'{base}/search', params={'q': 'test'})
+
 # invalid token attack
 bad_token = token[:-1] + 'x'
 headers_bad = {'Authorization': f'Bearer {bad_token}'}
@@ -23,7 +29,6 @@ except requests.RequestException:
     pass
 
 # request nonexistent endpoint
-headers = {'Authorization': f'Bearer {token}'}
 try:
     requests.get(f'{base}/admin', headers=headers)
 except requests.RequestException:

--- a/readme.md
+++ b/readme.md
@@ -27,4 +27,7 @@ behaviour, while abnormal ones describe suspicious or out‑of‑order actions.
 These JSON files can be executed via the capture routes to generate additional
 operation logs for model training.  Over thirty scenarios are now provided,
 covering e‑commerce purchases, cart operations, forum posts, error cases and
-stress patterns.
+stress patterns.  The latest version adds `/profile` and `/search` endpoints for
+profile management and public keyword lookup.  Normal scenarios now include a
+flow visiting these endpoints, while abnormal scenarios test unauthenticated
+access and out‑of‑order profile updates.

--- a/resource/server.js
+++ b/resource/server.js
@@ -25,7 +25,9 @@ const MAP = {
   '/login':  { use_case: 'Login',       type: 'AUTH'   },
   '/logout': { use_case: 'Logout',      type: 'AUTH'   },
   '/browse': { use_case: 'ViewPage',    type: 'READ'   },
-  '/edit':   { use_case: 'EditContent', type: 'UPDATE' }
+  '/edit':   { use_case: 'EditContent', type: 'UPDATE' },
+  '/profile': { use_case: 'Profile',    type: 'UPDATE' },
+  '/search':  { use_case: 'Search',     type: 'READ' }
 };
 // ──────────────────────────────────────────────────────
 
@@ -137,6 +139,42 @@ app.post('/edit', auth, (req, res) => {
     label: 'normal'
   });
   res.json({ message: 'Edit completed (dummy).' });
+});
+
+// GET /profile : 認証必須
+app.get('/profile', auth, (req, res) => {
+  writeLog({
+    userId: req.user.user_id,
+    endpoint: '/profile',
+    ip: getClientIP(req),
+    payload: req.user,
+    label: 'normal'
+  });
+  res.json({ profile: { user_id: req.user.user_id } });
+});
+
+// POST /profile : 認証必須
+app.post('/profile', auth, (req, res) => {
+  writeLog({
+    userId: req.user.user_id,
+    endpoint: '/profile',
+    ip: getClientIP(req),
+    payload: req.body,
+    label: 'normal'
+  });
+  res.json({ message: 'Profile updated.' });
+});
+
+// GET /search : 認証不要
+app.get('/search', (req, res) => {
+  writeLog({
+    userId: 'guest',
+    endpoint: '/search',
+    ip: getClientIP(req),
+    payload: req.query,
+    label: 'normal'
+  });
+  res.json({ results: [] });
 });
 
 // POST /logout : 認証必須


### PR DESCRIPTION
## Summary
- implement `/profile` (GET/POST) and `/search` endpoints
- record new endpoints in MAP for logging
- extend normal and abnormal loggers with scenarios using the new endpoints
- update attack script and README description

## Testing
- `npm test`
- `node resource/normal_logger.js 1 10`
- `node resource/abnormal_logger.js 1 10`


------
https://chatgpt.com/codex/tasks/task_e_686ccdb0530483278125fce3b9e0b686