### PR TITLE
Add LSTM training script

### DIFF
--- a/lstm_train.py
+++ b/lstm_train.py
@@ -1,0 +1,88 @@
+import argparse
+import csv
+import os
+from collections import defaultdict
+
+try:
+    from tensorflow.keras.models import Sequential, load_model
+    from tensorflow.keras.layers import Embedding, LSTM, Dense
+    from tensorflow.keras.preprocessing.sequence import pad_sequences
+except ImportError:  # pragma: no cover - tensorflow not installed
+    Sequential = load_model = Embedding = LSTM = Dense = pad_sequences = None
+
+# --- データ読み込み -----------------------------------------------------
+
+def read_sequences(csv_file):
+    """CSV からユーザー単位の操作系列を抽出"""
+    sequences = defaultdict(list)
+    with open(csv_file, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            uid = row.get('now_id') or row.get('user_id')
+            sequences[uid].append(row['endpoint'])
+    return list(sequences.values())
+
+
+def build_vocab(seqs):
+    vocab = {}
+    for s in seqs:
+        for e in s:
+            if e not in vocab:
+                vocab[e] = len(vocab) + 1  # 0 reserved for padding
+    return vocab
+
+
+def encode_sequences(seqs, vocab):
+    return [[vocab[e] for e in s] for s in seqs]
+
+
+# --- モデル構築 ---------------------------------------------------------
+
+def create_model(vocab_size, embedding_dim=32, lstm_units=32):
+    model = Sequential([
+        Embedding(vocab_size + 1, embedding_dim, mask_zero=True),
+        LSTM(lstm_units),
+        Dense(1, activation='sigmoid')
+    ])
+    model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])
+    return model
+
+
+# --- メイン -------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description='LSTM 学習スクリプト')
+    ap.add_argument('--normal', default=os.path.join('resource', 'logs', 'normal_log.csv'),
+                    help='正常ログCSVのパス')
+    ap.add_argument('--abnormal', default=os.path.join('resource', 'logs', 'abnormal_log.csv'),
+                    help='異常ログCSVのパス')
+    ap.add_argument('--model', default='lstm_model.h5', help='保存/読み込みするモデルパス')
+    args = ap.parse_args()
+
+    if Sequential is None:
+        print('TensorFlow がインストールされていません')
+        return
+
+    normal_seqs = read_sequences(args.normal)
+    abnormal_seqs = read_sequences(args.abnormal)
+
+    all_seqs = normal_seqs + abnormal_seqs
+    vocab = build_vocab(all_seqs)
+    X = encode_sequences(all_seqs, vocab)
+    y = [0] * len(normal_seqs) + [1] * len(abnormal_seqs)
+
+    max_len = max(len(s) for s in X)
+    X_pad = pad_sequences(X, maxlen=max_len)
+
+    if os.path.exists(args.model):
+        model = load_model(args.model)
+    else:
+        model = create_model(len(vocab))
+
+    model.fit(X_pad, y, epochs=10, batch_size=8, validation_split=0.2)
+    model.save(args.model)
+    print('モデル保存:', args.model)
+
+
+if __name__ == '__main__':
+    main()

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,16 @@ stress patterns.  The latest version adds `/profile` and `/search` endpoints for
 profile management and public keyword lookup.  Normal scenarios now include a
 flow visiting these endpoints, while abnormal scenarios test unauthenticated
 access and out‑of‑order profile updates.
+
+### LSTM Training
+
+A simple TensorFlow based trainer is provided to learn normal vs abnormal
+operation sequences.  Use `lstm_train.py` to train or update the model:
+
+```bash
+python lstm_train.py --model my_model.h5
+```
+
+Normal and abnormal CSV logs from `resource/logs/` are used by default. Pass
+`--normal` or `--abnormal` to specify different files.  When the model path is
+already present it will be loaded and further trained.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 PyJWT
+
+tensorflow>=2.12


### PR DESCRIPTION
## Summary
- add TensorFlow-based LSTM trainer `lstm_train.py`
- document how to run the trainer
- add tensorflow to Python requirements

## Testing
- `python lstm_train.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686ccf9c1a048327beaf89a31e7ca134