### PR TITLE
Add YAML config for LSTM training

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,10 @@
+model:
+  embedding_dim: 32
+  lstm_units: 32
+  epochs: 10
+  batch_size: 8
+  path: lstm_model.h5
+data:
+  normal: resource/logs/normal_log.csv
+  abnormal: resource/logs/abnormal_log.csv
+GPU: null

--- a/lstm_train.py
+++ b/lstm_train.py
@@ -2,18 +2,32 @@ import argparse
 import csv
 import os
 from collections import defaultdict
+import yaml
 
-# --- GPU オプション先読み ---------------------------------------------
+# --- GPU / 設定ファイル オプション先読み ------------------------------
 pre_ap = argparse.ArgumentParser(add_help=False)
 pre_ap.add_argument('--gpu', type=int, default=None,
                     help='利用するGPU番号。指定しない場合はCPUのみを使用')
+pre_ap.add_argument('--config', default='config.yaml',
+                    help='設定ファイル YAML のパス')
 pre_args, _ = pre_ap.parse_known_args()
-if pre_args.gpu is None:
+
+# 設定ファイルから GPU 指定がある場合は取得
+cfg_gpu = None
+if os.path.exists(pre_args.config):
+    with open(pre_args.config, 'r') as f:
+        cfg = yaml.safe_load(f) or {}
+        cfg_gpu = cfg.get('GPU')
+else:
+    cfg = {}
+
+gpu_id = pre_args.gpu if pre_args.gpu is not None else cfg_gpu
+if gpu_id is None:
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
     print('GPU を使用せずに学習を実行します')
 else:
-    os.environ['CUDA_VISIBLE_DEVICES'] = str(pre_args.gpu)
-    print(f'GPU {pre_args.gpu} を使用して学習を実行します')
+    os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
+    print(f'GPU {gpu_id} を使用して学習を実行します')
 
 try:
     from tensorflow.keras.models import Sequential, load_model
@@ -63,22 +77,38 @@ def create_model(vocab_size, embedding_dim=32, lstm_units=32):
 # --- メイン -------------------------------------------------------------
 
 def main():
-    ap = argparse.ArgumentParser(description='LSTM 学習スクリプト')
+    ap = argparse.ArgumentParser(description='LSTM 学習スクリプト',
+                                 parents=[pre_ap])
     ap.add_argument('--normal', default=os.path.join('resource', 'logs', 'normal_log.csv'),
                     help='正常ログCSVのパス')
     ap.add_argument('--abnormal', default=os.path.join('resource', 'logs', 'abnormal_log.csv'),
                     help='異常ログCSVのパス')
-    ap.add_argument('--model', default='lstm_model.h5', help='保存/読み込みするモデルパス')
-    ap.add_argument('--gpu', type=int, default=pre_args.gpu,
-                    help='利用するGPU番号。指定しない場合はCPUのみを使用')
+    ap.add_argument('--model', default=None, help='保存/読み込みするモデルパス')
     args = ap.parse_args()
+
+    # YAML 設定の読み込み
+    cfg = {}
+    if os.path.exists(args.config):
+        with open(args.config, 'r') as f:
+            cfg = yaml.safe_load(f) or {}
+
+    model_cfg = cfg.get('model', {})
+
+    normal_path = cfg.get('data', {}).get('normal', args.normal)
+    abnormal_path = cfg.get('data', {}).get('abnormal', args.abnormal)
+    model_path = args.model or model_cfg.get('path', 'lstm_model.h5')
+
+    embedding_dim = model_cfg.get('embedding_dim', 32)
+    lstm_units = model_cfg.get('lstm_units', 32)
+    epochs = model_cfg.get('epochs', 10)
+    batch_size = model_cfg.get('batch_size', 8)
 
     if Sequential is None:
         print('TensorFlow がインストールされていません')
         return
 
-    normal_seqs = read_sequences(args.normal)
-    abnormal_seqs = read_sequences(args.abnormal)
+    normal_seqs = read_sequences(normal_path)
+    abnormal_seqs = read_sequences(abnormal_path)
 
     all_seqs = normal_seqs + abnormal_seqs
     vocab = build_vocab(all_seqs)
@@ -88,14 +118,14 @@ def main():
     max_len = max(len(s) for s in X)
     X_pad = pad_sequences(X, maxlen=max_len)
 
-    if os.path.exists(args.model):
-        model = load_model(args.model)
+    if os.path.exists(model_path):
+        model = load_model(model_path)
     else:
-        model = create_model(len(vocab))
+        model = create_model(len(vocab), embedding_dim, lstm_units)
 
-    model.fit(X_pad, y, epochs=10, batch_size=8, validation_split=0.2)
-    model.save(args.model)
-    print('モデル保存:', args.model)
+    model.fit(X_pad, y, epochs=epochs, batch_size=batch_size, validation_split=0.2)
+    model.save(model_path)
+    print('モデル保存:', model_path)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 PyJWT
 
 tensorflow>=2.12
+PyYAML


### PR DESCRIPTION
## Summary
- manage training hyperparameters via YAML
- read config at startup to allow GPU/paths from YAML
- document PyYAML requirement
- add sample `config.yaml`

## Testing
- `npm test` *(fails: `ModuleNotFoundError: No module named 'requests'`)*

------
https://chatgpt.com/codex/tasks/task_e_686cd38060288327b2a225abe42bece2