### PR TITLE
Implement session cleanup with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "uuid": "^11.1.0"
   },
   "scripts": {
-    "test": "node run.js"
+    "test": "node run.js",
+    "unit-test": "node test/cleanup.test.js"
   },
   "devDependencies": {
     "puppeteer": "^24.10.2"

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const { sessions, tokenMap, cleanupStale, EXPIRE_MS } = require('../src/middlewares/recordSession');
+
+const now = Date.now();
+
+sessions.set('old', { start: now - 2 * EXPIRE_MS, last: now - 2 * EXPIRE_MS });
+sessions.set('new', { start: now, last: now });
+
+tokenMap.set('oldToken', { ip: '1.1.1.1', ua: 'test', last: now - 2 * EXPIRE_MS });
+tokenMap.set('newToken', { ip: '1.1.1.1', ua: 'test', last: now });
+
+cleanupStale();
+
+assert.strictEqual(sessions.has('old'), false);
+assert.strictEqual(sessions.has('new'), true);
+assert.strictEqual(tokenMap.has('oldToken'), false);
+assert.strictEqual(tokenMap.has('newToken'), true);
+
+console.log('cleanupStale test passed');


### PR DESCRIPTION
## Summary
- add expiry and periodic cleanup for in-memory session/token data
- update token map to track last access time
- export cleanup utilities for testing
- add unit test for cleanup logic

## Testing
- `npm run unit-test`
- `npm test` *(fails: ModuleNotFoundError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_686d05dc6558832799ab6329df53961b