### PR TITLE
Update sequence trainer to use YAML config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,4 +7,11 @@ model:
 data:
   normal: resource/logs/normal_log.csv
   abnormal: resource/logs/abnormal_log.csv
+  sequence_log: resource/logs/normal_log.csv
+sequence_model:
+  units: 100
+  dropout: 0.0
+  epochs: 20
+  second_lstm: false
+  path: seq_model.h5
 GPU: null

--- a/lstm_sequence_train.py
+++ b/lstm_sequence_train.py
@@ -2,12 +2,36 @@ import argparse
 import csv
 import os
 from collections import defaultdict
+import yaml
 
 import numpy as np
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import LSTM, Dropout, TimeDistributed, Dense
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 from tensorflow.keras.utils import to_categorical
+
+# --- GPU / 設定ファイル オプション先読み ------------------------------
+pre_ap = argparse.ArgumentParser(add_help=False)
+pre_ap.add_argument('--gpu', type=int, default=None,
+                    help='利用するGPU番号。指定しない場合はCPUのみを使用')
+pre_ap.add_argument('--config', default='config.yaml',
+                    help='設定ファイル YAML のパス')
+pre_args, _ = pre_ap.parse_known_args()
+
+cfg_gpu = None
+cfg = {}
+if os.path.exists(pre_args.config):
+    with open(pre_args.config, 'r') as f:
+        cfg = yaml.safe_load(f) or {}
+        cfg_gpu = cfg.get('GPU')
+
+gpu_id = pre_args.gpu if pre_args.gpu is not None else cfg_gpu
+if gpu_id is None:
+    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+    print('GPU を使用せずに学習を実行します')
+else:
+    os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
+    print(f'GPU {gpu_id} を使用して学習を実行します')
 
 
 def read_sequences(csv_file):
@@ -62,24 +86,33 @@ def create_model(num_endpoints, units=100, dropout_rate=0.0, second_lstm=False):
 
 
 def main():
-    ap = argparse.ArgumentParser(description='次操作予測用 LSTM 学習')
-    ap.add_argument('--log', default=os.path.join('resource', 'logs', 'normal_log.csv'),
-                    help='学習用ログCSV')
-    ap.add_argument('--model', default='seq_model.h5', help='保存するモデルファイル')
-    ap.add_argument('--epochs', type=int, default=20)
-    ap.add_argument('--units', type=int, default=100)
-    ap.add_argument('--dropout', type=float, default=0.0)
+    ap = argparse.ArgumentParser(description='次操作予測用 LSTM 学習',
+                                 parents=[pre_ap])
+    ap.add_argument('--log', default=None, help='学習用ログCSV')
+    ap.add_argument('--model', default=None, help='保存するモデルファイル')
+    ap.add_argument('--epochs', type=int, default=None)
+    ap.add_argument('--units', type=int, default=None)
+    ap.add_argument('--dropout', type=float, default=None)
     ap.add_argument('--second_lstm', action='store_true', help='2層目のLSTMを追加')
     args = ap.parse_args()
 
-    seqs = read_sequences(args.log)
+    seq_log = args.log or cfg.get('data', {}).get('sequence_log',
+                        os.path.join('resource', 'logs', 'normal_log.csv'))
+    model_cfg = cfg.get('sequence_model', {})
+    model_path = args.model or model_cfg.get('path', 'seq_model.h5')
+    epochs = args.epochs if args.epochs is not None else model_cfg.get('epochs', 20)
+    units = args.units if args.units is not None else model_cfg.get('units', 100)
+    dropout = args.dropout if args.dropout is not None else model_cfg.get('dropout', 0.0)
+    second = args.second_lstm or model_cfg.get('second_lstm', False)
+
+    seqs = read_sequences(seq_log)
     vocab = build_vocab(seqs)
     X, y = create_dataset(seqs, vocab)
 
-    model = create_model(len(vocab) + 1, args.units, args.dropout, args.second_lstm)
-    model.fit(X, y, epochs=args.epochs, batch_size=8, validation_split=0.2)
-    model.save(args.model)
-    print('モデル保存:', args.model)
+    model = create_model(len(vocab) + 1, units, dropout, second)
+    model.fit(X, y, epochs=epochs, batch_size=8, validation_split=0.2)
+    model.save(model_path)
+    print('モデル保存:', model_path)
 
 
 if __name__ == '__main__':

--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,10 @@ python lstm_train.py --model my_model.h5 --output-dir runs/gpu --gpu 0
 
 ### 次ステップ予測
 
-各時点で次のエンドポイントを予測するシーケンス学習には `lstm_sequence_train.py` を使用します。
+各時点で次のエンドポイントを予測するシーケンス学習には `lstm_sequence_train.py` を使用します。主要なパラメータは `config.yaml` の `sequence_model` セクションにまとめられており、`--gpu` オプションでGPUを指定できます。
 
 ```bash
-python lstm_sequence_train.py --log resource/logs/normal_log.csv --model seq_model.h5
+python lstm_sequence_train.py --gpu 0
 ```
 
 このモデルはワンホット入力を用い、各時刻ごとに利用可能なエンドポイントの分布を出力します。
@@ -86,12 +86,14 @@ python lstm_sequence_train.py --log resource/logs/normal_log.csv --model seq_mod
 |  | `--abnormal` | `resource/logs/abnormal_log.csv` | 異常ログ CSV |
 |  | `--model` | `lstm_model.h5` | モデルファイル |
 |  | `--output-dir` | `<モデル名_日付>` | 学習結果保存先 |
-| lstm_sequence_train.py | `--log` | `resource/logs/normal_log.csv` | 学習用ログ |
-|  | `--model` | `seq_model.h5` | 保存するモデル |
-|  | `--epochs` | `20` | エポック数 |
-|  | `--units` | `100` | LSTM ユニット数 |
-|  | `--dropout` | `0.0` | Dropout 率 |
-|  | `--second_lstm` | `false` | 2 層目 LSTM を追加 |
+| lstm_sequence_train.py | `--gpu` | `None` または `config.yaml` の `GPU` | 使用 GPU |
+|  | `--config` | `config.yaml` | 設定ファイルパス |
+|  | `--log` | `config.yaml` の `data.sequence_log` | 学習用ログ |
+|  | `--model` | `config.yaml` の `sequence_model.path` | 保存するモデル |
+|  | `--epochs` | `config.yaml` の `sequence_model.epochs` | エポック数 |
+|  | `--units` | `config.yaml` の `sequence_model.units` | LSTM ユニット数 |
+|  | `--dropout` | `config.yaml` の `sequence_model.dropout` | Dropout 率 |
+|  | `--second_lstm` | `config.yaml` の `sequence_model.second_lstm` | 2 層目 LSTM を追加 |
 | resource/normal_logger.js | `[系列数]` | `100` | 生成する正常系列数 |
 |  | `[delay_ms]` | `100` | 各系列間の待ち時間(ms) |
 | resource/abnormal_logger.js | `[系列数]` | `100` | 生成する異常系列数 |
@@ -107,5 +109,11 @@ python lstm_sequence_train.py --log resource/logs/normal_log.csv --model seq_mod
 |  | `model.path` | `lstm_model.h5` | モデルパス |
 |  | `data.normal` | `resource/logs/normal_log.csv` | 正常ログ CSV |
 |  | `data.abnormal` | `resource/logs/abnormal_log.csv` | 異常ログ CSV |
+|  | `data.sequence_log` | `resource/logs/normal_log.csv` | シーケンス学習用ログ |
+|  | `sequence_model.units` | `100` | シーケンス LSTM ユニット数 |
+|  | `sequence_model.dropout` | `0.0` | Dropout 率 |
+|  | `sequence_model.epochs` | `20` | シーケンス学習エポック数 |
+|  | `sequence_model.second_lstm` | `false` | 2 層目 LSTM 使用有無 |
+|  | `sequence_model.path` | `seq_model.h5` | シーケンスモデルパス |
 |  | `GPU` | `null` | 使用 GPU 番号 (無指定時 CPU) |
 


### PR DESCRIPTION
## Summary
- add sequence_model section to `config.yaml`
- enable YAML-based parameter loading and `--gpu` option in `lstm_sequence_train.py`
- update documentation with new usage and configuration keys

## Testing
- `npm run unit-test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_686d310b37b48327bc3fb1d50aeb2cc4