### PR TITLE
短いオプション名に統一

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ npm test
 手動で正常系列だけを記録したい場合は、`resource/normal_logger.js` を実行します。以下のプロンプトを参考にしてください。
 
 ```bash
-node resource/normal_logger.js 50 100
+node resource/normal_logger.js --n 50 --d 100
 ```
 
 上記では 50 本の正常操作系列を 100ms 間隔で生成し、結果は `resource/logs/normal_log.csv` に追記されます。
@@ -34,7 +34,7 @@ node resource/normal_logger.js 50 100
 異常操作系列を生成するには `resource/abnormal_logger.js` を使用します。
 
 ```bash
-node resource/abnormal_logger.js 50 100
+node resource/abnormal_logger.js --n 50 --d 100
 ```
 
 こちらは 50 本のランダムな異常シナリオを出力し、`resource/logs/abnormal_log.csv` に保存します。
@@ -94,14 +94,14 @@ python lstm_sequence_train.py --gpu 0
 |  | `--units` | `config.yaml` の `sequence_model.units` | LSTM ユニット数 |
 |  | `--dropout` | `config.yaml` の `sequence_model.dropout` | Dropout 率 |
 |  | `--second_lstm` | `config.yaml` の `sequence_model.second_lstm` | 2 層目 LSTM を追加 |
-| resource/normal_logger.js | `[系列数]` | `100` | 生成する正常系列数 |
-|  | `[delay_ms]` | `100` | 各系列間の待ち時間(ms) |
-| resource/abnormal_logger.js | `[系列数]` | `100` | 生成する異常系列数 |
-|  | `[delay_ms]` | `100` | 各系列間の待ち時間(ms) |
-| test.js | `[normal_total]` | `100` | 正常系列数 |
-|  | `[normal_delay]` | `100` | 正常 delay(ms) |
-|  | `[abnormal_total]` | `100` | 異常系列数 |
-|  | `[abnormal_delay]` | `100` | 異常 delay(ms) |
+| resource/normal_logger.js | `--n` | `100` | 生成する正常系列数 |
+|  | `--d` | `100` | 各系列間の待ち時間(ms) |
+| resource/abnormal_logger.js | `--n` | `100` | 生成する異常系列数 |
+|  | `--d` | `100` | 各系列間の待ち時間(ms) |
+| test.js | `--n` | `100` | 正常系列数 |
+|  | `--d` | `100` | 正常 delay(ms) |
+|  | `--an` | `100` | 異常系列数 |
+|  | `--ad` | `100` | 異常 delay(ms) |
 | config.yaml | `model.embedding_dim` | `128` | 埋め込み次元数 |
 |  | `model.lstm_units` | `100` | LSTM ユニット数 |
 |  | `model.epochs` | `300` | 学習エポック数 |

--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -1,9 +1,9 @@
 /**
  * 異常操作系列を自動生成して abnormal_log.csv に保存
  *
- *  呼び出し: node abnormal_logger.js [系列数] [delay_ms]
- *     系列数   : デフォルト 100
- *     delay_ms : 各系列間ウェイト (ms) デフォルト 100
+ *  呼び出し: node abnormal_logger.js --n 50 --d 100
+ *     --n 系列数   (default 100)
+ *     --d delay_ms (ms, default 100)
  */
 
 const axios = require('axios');
@@ -38,6 +38,21 @@ const jpOctets = [43,49,58,59,60,61,101,103,106,110,111,112,113,114,115,116,118,
  219,220,221,222];
 const randomIP = () => [rand(jpOctets), randInt(0,255), randInt(0,255), randInt(1,254)].join('.');
 const USER_AGENT = 'abnormal-logger';
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  let total = 100;
+  let delay = 100;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--n') {
+      total = parseInt(argv[i + 1], 10) || total;
+      i++;
+    } else if (argv[i] === '--d') {
+      delay = parseInt(argv[i + 1], 10) || delay;
+      i++;
+    }
+  }
+  return { total, delay };
+}
 // token と発行者(user_id)の対応表
 const tokenMap = new Map();
 
@@ -328,8 +343,7 @@ const scenarios = [
 
 // ── メイン ───────────────────────────────────
 (async () => {
-  const total = parseInt(process.argv[2] || '100', 10);
-  const delay = parseInt(process.argv[3] || '100', 10);
+  const { total, delay } = parseArgs();
   console.log(`▶ 異常系列 ${total} 本 生成開始`);
 
   for (let i = 0; i < total; i++) {

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -1,9 +1,9 @@
 /**
  * 正常操作系列を自動生成して normal_log.csv に保存
  *
- *  呼び出し: node normal_logger.js [系列数] [delay_ms]
- *     系列数   : デフォルト 100
- *     delay_ms : 各系列間ウェイト (ms) デフォルト 100
+ *  呼び出し: node normal_logger.js --n 50 --d 100
+ *     --n 系列数   (default 100)
+ *     --d delay_ms (ms, default 100)
  */
 
 const axios = require('axios');
@@ -39,6 +39,21 @@ const jpOctets = [43,49,58,59,60,61,101,103,106,110,111,112,113,114,115,116,118,
 const rand = arr => arr[Math.floor(Math.random() * arr.length)];
 const randomIP = () => [rand(jpOctets), randInt(0,255), randInt(0,255), randInt(1,254)].join('.');
 const USER_AGENT = 'normal-logger';
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  let total = 100;
+  let delay = 100;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--n') {
+      total = parseInt(argv[i + 1], 10) || total;
+      i++;
+    } else if (argv[i] === '--d') {
+      delay = parseInt(argv[i + 1], 10) || delay;
+      i++;
+    }
+  }
+  return { total, delay };
+}
 function extractPayload(token) {
   try {
     const payloadPart = token.split('.')[1];
@@ -259,8 +274,7 @@ async function normalSequence(userId) {
 
 // ── メイン ───────────────────────────────────
 (async () => {
-  const total = parseInt(process.argv[2] || '100', 10);
-  const delay = parseInt(process.argv[3] || '100', 10);
+  const { total, delay } = parseArgs();
   console.log(`▶ 正常系列 ${total} 本 生成開始`);
 
   for (let i = 0; i < total; i++) {

--- a/test.js
+++ b/test.js
@@ -2,6 +2,18 @@ const { spawn, spawnSync } = require('child_process');
 const path = require('path');
 const readline = require('readline');
 
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const o = { n: DEFAULT_TOTAL, d: DEFAULT_DELAY, an: DEFAULT_TOTAL, ad: DEFAULT_DELAY };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--n') { o.n = parseInt(argv[i + 1], 10) || o.n; i++; }
+    else if (argv[i] === '--d') { o.d = parseInt(argv[i + 1], 10) || o.d; i++; }
+    else if (argv[i] === '--an') { o.an = parseInt(argv[i + 1], 10) || o.an; i++; }
+    else if (argv[i] === '--ad') { o.ad = parseInt(argv[i + 1], 10) || o.ad; i++; }
+  }
+  return o;
+}
+
 const server = spawn('node', [path.join('resource', 'server.js')], {
   stdio: 'inherit'
 });
@@ -13,7 +25,7 @@ const DEFAULT_DELAY = 100;
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   const question = q => new Promise(resolve => rl.question(q, resolve));
 
-  const args = process.argv.slice(2).map(v => parseInt(v, 10));
+  const opts = parseArgs();
 
   async function getNumber(val, text, def) {
     if (!isNaN(val)) return val;
@@ -22,22 +34,22 @@ const DEFAULT_DELAY = 100;
   }
 
   const normalTotal = await getNumber(
-    args[0],
+    opts.n,
     `正常系列数? (default ${DEFAULT_TOTAL}): `,
     DEFAULT_TOTAL
   );
   const normalDelay = await getNumber(
-    args[1],
+    opts.d,
     `正常 delay (ms)? (default ${DEFAULT_DELAY}): `,
     DEFAULT_DELAY
   );
   const abnormalTotal = await getNumber(
-    args[2],
+    opts.an,
     `異常系列数? (default ${DEFAULT_TOTAL}): `,
     DEFAULT_TOTAL
   );
   const abnormalDelay = await getNumber(
-    args[3],
+    opts.ad,
     `異常 delay (ms)? (default ${DEFAULT_DELAY}): `,
     DEFAULT_DELAY
   );
@@ -48,8 +60,8 @@ const DEFAULT_DELAY = 100;
     console.log('\n-- normal_logger --');
     const normalArgs = [
       path.join('resource', 'normal_logger.js'),
-      String(normalTotal),
-      String(normalDelay)
+      '--n', String(normalTotal),
+      '--d', String(normalDelay)
 
     ];
     spawnSync('node', normalArgs, { stdio: 'inherit' });
@@ -57,8 +69,8 @@ const DEFAULT_DELAY = 100;
     console.log('\n-- abnormal_logger --');
     const abnormalArgs = [
       path.join('resource', 'abnormal_logger.js'),
-      String(abnormalTotal),
-      String(abnormalDelay)
+      '--n', String(abnormalTotal),
+      '--d', String(abnormalDelay)
 
     ];
     spawnSync('node', abnormalArgs, { stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- normal_logger.js と abnormal_logger.js を `--n` と `--d` オプションで実行できるよう変更
- test.js も新オプションに対応
- README の使用例とオプション表を更新

## Testing
- `npm run unit-test` *(失敗: csv-writer が見つからず)*
- `pytest -q` *(失敗: yaml モジュール無し)*


------
https://chatgpt.com/codex/tasks/task_e_686d35626ff08327928cb772c72ec540