### PR TITLE
Implement npm test with log generation and LSTM training

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,8 @@
 model:
   embedding_dim: 128
   lstm_units: 100
-  epochs: 300
-  batch_size: 16
+  epochs: 2
+  batch_size: 4
   path: lstm_model.h5
 data:
   normal: resource/logs/normal_log.csv

--- a/lstm_train.py
+++ b/lstm_train.py
@@ -4,6 +4,7 @@ import os
 from collections import defaultdict, Counter
 from datetime import datetime
 import yaml
+import numpy as np
 
 try:
     import matplotlib.pyplot as plt
@@ -160,7 +161,7 @@ def main():
     all_seqs = normal_seqs + abnormal_seqs
     vocab = build_vocab(all_seqs)
     X = encode_sequences(all_seqs, vocab)
-    y = [0] * len(normal_seqs) + [1] * len(abnormal_seqs)
+    y = np.array([0] * len(normal_seqs) + [1] * len(abnormal_seqs), dtype='int32')
 
     max_len = max(len(s) for s in X)
     X_pad = pad_sequences(X, maxlen=max_len)

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,13 @@ npm install
 pip install -r requirements.txt
 ```
 
-次に npm 経由で攻撃シーケンスを実行します。
+次に npm 経由でテストを実行します。
 
 ```bash
 npm test
 ```
 
-ログは `resource/logs/request_log.csv` に書き出されます。
+このコマンドではサーバを起動し、正常ログと異常ログを取得した後、正常ログを用いた LSTM 学習と評価を自動的に行います。生成されたログは `resource/logs/normal_log.csv` と `resource/logs/abnormal_log.csv` に保存されます。
 
 ### 正常ログの取得
 


### PR DESCRIPTION
## Summary
- run normal/abnormal loggers and LSTM training in `npm test`
- shorten training configuration for quick runs
- fix numpy dtype issue in `lstm_train.py`
- document new test workflow

## Testing
- `npm test`
- `npm run unit-test` *(fails: Cannot find module 'csv-writer')*

------
https://chatgpt.com/codex/tasks/task_e_686d43e674088327bc1cb36b65bd2c17