### PR TITLE
Expand log fields in client loggers

### DIFF
--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -15,6 +15,17 @@ const updateOperationLog = require('./update_operation_log');
 const SECRET = 'change_this_to_env_secret';
 const LOG_FILE = path.join(__dirname, 'logs', 'abnormal_log.csv');
 
+// logging fields (server.js と同一順)
+const FIELDS = [
+  'timestamp','epoch_ms','user_id','session_id','user_role','auth_method','ip',
+  'geo_location','user_agent','device_type','platform','method','endpoint',
+  'use_case','type','target_id','endpoint_group','referrer','api_version',
+  'status_code','response_time_ms','content_length','success','jwt_payload_sub',
+  'jwt_payload_exp','token_reuse_detected','login_state','time_since_login',
+  'actions_in_session','previous_action','next_action_expected','label',
+  'abnormal_type','severity','comment','debug_info'
+];
+
 const MAP = {
   '/login':  { use_case: 'Login',       type: 'AUTH'   },
   '/logout': { use_case: 'Logout',      type: 'AUTH'   },
@@ -27,7 +38,7 @@ const MAP = {
 if (!fs.existsSync(path.dirname(LOG_FILE))) fs.mkdirSync(path.dirname(LOG_FILE));
   fs.writeFileSync(
     LOG_FILE,
-    'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt_payload,label\n'
+    FIELDS.join(',') + '\n'
   );
 
 const api = axios.create({ baseURL: 'http://localhost:3000', timeout: 5000 });
@@ -76,32 +87,88 @@ const tokenMap = new Map();
 
 const registerToken = (token, userId) => tokenMap.set(token, userId);
 const getIssuer = token => tokenMap.get(token) || 'unknown';
-function extractPayload(token) {
+// セッション管理
+const sessions = new Map(); // token -> { loginTime, actionCount, lastAction }
+
+function decodePayload(token) {
   try {
-    const payloadPart = token.split('.')[1];
-    const json = Buffer.from(payloadPart, 'base64url').toString();
-    const obj  = JSON.parse(json);
-    return Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const json = Buffer.from(token.split('.')[1], 'base64url').toString();
+    return JSON.parse(json);
   } catch (_) {
-    return 'invalid';
+    return null;
   }
 }
-function logRow({ ts, userId, nowId, endpoint, ip, token = 'none', label }) {
-  const { use_case = 'unknown', type = 'unknown' } = MAP[endpoint] || {};
-  fs.appendFileSync(
-    LOG_FILE,
-    [
-      ts,
-      userId,
-      nowId,
-      endpoint,
-      use_case,
-      type,
-      ip,
-      extractPayload(token),
-      label
-    ].join(',') + '\n'
-  );
+
+function logRow(obj) {
+  const line = FIELDS.map(f => (obj[f] !== undefined ? String(obj[f]) : ''))
+    .join(',') + '\n';
+  fs.appendFileSync(LOG_FILE, line);
+}
+
+async function requestAndLog({ method, endpoint, data, token, userId, ip, label, abnormal_type }) {
+  const headers = { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const start = Date.now();
+  let res;
+  try {
+    res = await api.request({ method, url: endpoint, data, headers });
+  } catch (err) {
+    res = err.response || { status: 0, headers: {}, data: {} };
+  }
+  const now = Date.now();
+  const session = token ? sessions.get(token) : null;
+  const payload = token ? decodePayload(token) : null;
+  const log = {
+    timestamp: new Date(start).toISOString(),
+    epoch_ms: start,
+    user_id: userId,
+    session_id: token ? token.slice(-8) : 'guest',
+    user_role: '-',
+    auth_method: token ? 'jwt' : 'none',
+    ip,
+    geo_location: '-',
+    user_agent: USER_AGENT,
+    device_type: /mobile/i.test(USER_AGENT) ? 'mobile' : 'pc',
+    platform: process.platform,
+    method: method.toUpperCase(),
+    endpoint,
+    use_case: MAP[endpoint]?.use_case || 'unknown',
+    type: MAP[endpoint]?.type || 'unknown',
+    target_id: data && data.id ? data.id : '',
+    endpoint_group: endpoint.split('/')[1] || '',
+    referrer: '',
+    api_version: ((endpoint.split('/')[1] || '').match(/^v\d+/) || [''])[0],
+    status_code: res.status,
+    response_time_ms: now - start,
+    content_length: res.headers['content-length'] || 0,
+    success: res.status < 400,
+    jwt_payload_sub: payload ? (payload.sub || payload.user_id || '') : '',
+    jwt_payload_exp: payload ? payload.exp || '' : '',
+    token_reuse_detected: '',
+    login_state: token ? 'logged_in' : 'guest',
+    time_since_login: session ? now - session.loginTime : '',
+    actions_in_session: session ? session.actionCount : '',
+    previous_action: session ? session.lastAction : '',
+    next_action_expected: '',
+    label,
+    abnormal_type: abnormal_type || '',
+    severity: '',
+    comment: '',
+    debug_info: ''
+  };
+  logRow(log);
+  if (token) {
+    if (!session) {
+      sessions.set(token, { loginTime: start, actionCount: 1, lastAction: MAP[endpoint]?.use_case || endpoint });
+    } else {
+      session.actionCount++;
+      session.lastAction = MAP[endpoint]?.use_case || endpoint;
+    }
+  }
+  if (endpoint === '/login' && res.status < 400 && res.data.token) {
+    return res.data.token;
+  }
+  return token;
 }
 
 // ── 各異常シナリオ ───────────────────────────
@@ -114,76 +181,125 @@ async function invalidTokenSequence(userId) {
   // 発行された正規トークンを記録
   registerToken(data.token, userId);
   const badToken = data.token.slice(0, -1) + 'x';
-  const auth = {
-    headers: {
-      Authorization: `Bearer ${badToken}`,
-      'X-Forwarded-For': ip,
-      'User-Agent': USER_AGENT
-    }
-  };
-  const ts = new Date().toISOString();
-  try { await api.get('/browse', auth); } catch (_) {}
-  logRow({ ts, userId: getIssuer(badToken), nowId: userId, endpoint: '/browse', ip, token: badToken, label: 'invalid_token' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token: badToken,
+    userId: getIssuer(badToken),
+    ip,
+    label: 'invalid_token',
+    abnormal_type: 'invalid_token'
+  });
+  await humanDelay('/browse');
 }
 
 // 2) JWTなしアクセス
 async function noTokenSequence(userId = 'unknown') {
   const ip = randomIP();
-  const ts = new Date().toISOString();
-  try { await api.post('/edit', {}, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } }); } catch (_) {}
-  logRow({ ts, userId: 'unknown', nowId: userId, endpoint: '/edit', ip, token: 'none', label: 'no_token' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/edit',
+    data: {},
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'no_token',
+    abnormal_type: 'no_token'
+  });
   await humanDelay('/edit');
 }
 
 // 2b) 認証なしでプロフィール閲覧
 async function unauthorizedProfileSequence(userId = 'unknown') {
   const ip = randomIP();
-  const ts = new Date().toISOString();
-  try { await api.get('/profile', { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } }); } catch (_) {}
-  logRow({ ts, userId: 'unknown', nowId: userId, endpoint: '/profile', ip, token: 'none', label: 'no_token' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/profile',
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'no_token',
+    abnormal_type: 'no_token'
+  });
   await humanDelay('/profile');
 }
 
 // 3) 順序異常 (edit → login → logout)
 async function reversedSequence(userId) {
   const ip = randomIP();
-  const ts1 = new Date().toISOString();
-  try { await api.post('/edit', {}, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } }); } catch (_) {}
-  logRow({ ts: ts1, userId: 'unknown', nowId: userId, endpoint: '/edit', ip, token: 'none', label: 'no_token' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/edit',
+    data: {},
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'no_token',
+    abnormal_type: 'no_token'
+  });
   await humanDelay('/edit');
 
-  const { data } = await api.post('/login', { user_id: userId }, {
-    headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT }
+  const token = await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: { user_id: userId },
+    token: null,
+    userId,
+    ip,
+    label: 'normal'
   });
-  const token = data.token;
   registerToken(token, userId);
-  const auth = {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'X-Forwarded-For': ip,
-      'User-Agent': USER_AGENT
-    }
-  };
-  const ts2 = new Date().toISOString();
-  await api.post('/logout', {}, auth);
-  logRow({ ts: ts2, userId: getIssuer(token), nowId: userId, endpoint: '/logout', ip, token, label: 'out_of_order' });
+  await humanDelay('/login');
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/logout',
+    data: {},
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'out_of_order',
+    abnormal_type: 'out_of_order'
+  });
+  await humanDelay('/logout');
 }
 
 // 3b) プロフィール更新を先に実行
 async function profileBeforeLoginSequence(userId) {
   const ip = randomIP();
-  const ts1 = new Date().toISOString();
-  try { await api.post('/profile', { bio: 'x' }, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } }); } catch (_) {}
-  logRow({ ts: ts1, userId: 'unknown', nowId: userId, endpoint: '/profile', ip, token: 'none', label: 'no_token' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/profile',
+    data: { bio: 'x' },
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'no_token',
+    abnormal_type: 'no_token'
+  });
   await humanDelay('/profile');
 
-  const { data } = await api.post('/login', { user_id: userId }, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
-  const token = data.token;
+  const token = await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: { user_id: userId },
+    token: null,
+    userId,
+    ip,
+    label: 'normal'
+  });
   registerToken(token, userId);
-  const auth = { headers: { Authorization: `Bearer ${token}`, 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } };
-  const ts2 = new Date().toISOString();
-  await api.post('/logout', {}, auth);
-  logRow({ ts: ts2, userId: getIssuer(token), nowId: userId, endpoint: '/logout', ip, token, label: 'out_of_order' });
+  await humanDelay('/login');
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/logout',
+    data: {},
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'out_of_order',
+    abnormal_type: 'out_of_order'
+  });
+  await humanDelay('/logout');
 }
 
 // 4) 発行者と利用者が異なるトークン流用
@@ -206,17 +322,15 @@ async function tokenReuseSequence(nowId) {
   }
 
   const ip = randomIP();
-  const t = new Date().toISOString();
-  try {
-    await api.get('/browse', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'X-Forwarded-For': ip,
-        'User-Agent': USER_AGENT
-      }
-    });
-  } catch (_) {}
-  logRow({ ts: t, userId: issuerId, nowId, endpoint: '/browse', ip, token, label: 'token_reuse' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId: issuerId,
+    ip,
+    label: 'token_reuse',
+    abnormal_type: 'token_reuse'
+  });
   await humanDelay('/browse');
 }
 
@@ -228,20 +342,26 @@ async function reuseAfterLogoutSequence(userId) {
   });
   const token = data.token;
   registerToken(token, userId);
-  const auth = {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'X-Forwarded-For': ip,
-      'User-Agent': USER_AGENT
-    }
-  };
-  const t1 = new Date().toISOString();
-  await api.post('/logout', {}, auth);
-  logRow({ ts: t1, userId: getIssuer(token), nowId: userId, endpoint: '/logout', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/logout',
+    data: {},
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'normal'
+  });
 
-  const t2 = new Date().toISOString();
-  try { await api.get('/browse', auth); } catch (_) {}
-  logRow({ ts: t2, userId: getIssuer(token), nowId: userId, endpoint: '/browse', ip, token, label: 'reuse_after_logout' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'reuse_after_logout',
+    abnormal_type: 'reuse_after_logout'
+  });
+  await humanDelay('/browse');
 }
 
 // 6) 有効期限切れトークンの使用
@@ -249,27 +369,31 @@ async function expiredTokenSequence(userId) {
   const ip = randomIP();
   const token = jwt.sign({ user_id: userId }, SECRET, { expiresIn: '1s' });
   registerToken(token, userId);
-  const auth = {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'X-Forwarded-For': ip,
-      'User-Agent': USER_AGENT
-    }
-  };
   await sleep(1500);
-  const t = new Date().toISOString();
-  try { await api.get('/browse', auth); } catch (_) {}
-  logRow({ ts: t, userId: getIssuer(token), nowId: userId, endpoint: '/browse', ip, token, label: 'expired_token' });
-}
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'expired_token',
+    abnormal_type: 'expired_token'
+  });
+  }
 
 // 7) user_id なしでのログイン試行
 async function missingUserIdSequence(nowId = 'unknown') {
   const ip = randomIP();
-  const ts = new Date().toISOString();
-  try {
-    await api.post('/login', {}, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
-  } catch (_) {}
-  logRow({ ts, userId: 'unknown', nowId, endpoint: '/login', ip, token: 'none', label: 'missing_user_id' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: {},
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'missing_user_id',
+    abnormal_type: 'missing_user_id'
+  });
   await humanDelay('/login');
 }
 
@@ -279,10 +403,15 @@ async function invalidEndpointSequence(userId) {
   const { data } = await api.post('/login', { user_id: userId }, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
   const token = data.token;
   registerToken(token, userId);
-  const auth = { headers: { Authorization: `Bearer ${token}`, 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } };
-  const ts = new Date().toISOString();
-  try { await api.get('/admin', auth); } catch (_) {}
-  logRow({ ts, userId: getIssuer(token), nowId: userId, endpoint: '/admin', ip, token, label: 'invalid_endpoint' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/admin',
+    token,
+    userId: getIssuer(token),
+    ip,
+    label: 'invalid_endpoint',
+    abnormal_type: 'invalid_endpoint'
+  });
 }
 
 // 9) IP を切り替えて同一トークンを使用
@@ -292,26 +421,45 @@ async function ipSwitchSequence(userId) {
   const token = data.token;
   registerToken(token, userId);
   const ip2 = randomIP();
-  const auth = { headers: { Authorization: `Bearer ${token}`, 'X-Forwarded-For': ip2, 'User-Agent': USER_AGENT } };
-  const ts = new Date().toISOString();
-  try { await api.get('/browse', auth); } catch (_) {}
-  logRow({ ts, userId: getIssuer(token), nowId: userId, endpoint: '/browse', ip: ip2, token, label: 'ip_switch' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId: getIssuer(token),
+    ip: ip2,
+    label: 'ip_switch',
+    abnormal_type: 'ip_switch'
+  });
 }
 
 // 10) 過剰な連続ログイン
   async function rapidLoginSequence(userId) {
     const ip = randomIP();
     for (let i = 0; i < 5; i++) {
-      const ts = new Date().toISOString();
       try {
-        const { data } = await api.post('/login', { user_id: userId }, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
-        registerToken(data.token, userId);
-        logRow({ ts, userId, nowId: userId, endpoint: '/login', ip, token: data.token, label: 'rapid_login' });
-  await humanDelay('/login');
+        const token = await requestAndLog({
+          method: 'post',
+          endpoint: '/login',
+          data: { user_id: userId },
+          token: null,
+          userId,
+          ip,
+          label: 'rapid_login'
+        });
+        registerToken(token, userId);
       } catch (_) {
-        logRow({ ts, userId: 'unknown', nowId: userId, endpoint: '/login', ip, token: 'none', label: 'rapid_login' });
-  await humanDelay('/login');
+        await requestAndLog({
+          method: 'post',
+          endpoint: '/login',
+          data: {},
+          token: null,
+          userId: 'unknown',
+          ip,
+          label: 'rapid_login',
+          abnormal_type: 'rapid_login'
+        });
       }
+      await humanDelay('/login');
       await sleep(50);
     }
   }
@@ -320,37 +468,75 @@ async function ipSwitchSequence(userId) {
 async function complexSequence(userId) {
   const ip = randomIP();
   // 正常ログイン
-  const { data } = await api.post('/login', { user_id: userId }, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
-  const token = data.token;
+  const token = await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: { user_id: userId },
+    token: null,
+    userId,
+    ip,
+    label: 'normal'
+  });
   registerToken(token, userId);
-  const auth = { headers: { Authorization: `Bearer ${token}`, 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } };
-  const t1 = new Date().toISOString();
-  await api.get('/browse', auth);
-  logRow({ ts: t1, userId, nowId: userId, endpoint: '/browse', ip, token, label: 'normal' });
+  await humanDelay('/login');
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/browse');
 
   // ログアウト
-  const t2 = new Date().toISOString();
-  await api.post('/logout', {}, auth);
-  logRow({ ts: t2, userId, nowId: userId, endpoint: '/logout', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/logout',
+    data: {},
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/logout');
 
   // ログアウト済みトークンで操作
-  const t3 = new Date().toISOString();
-  try { await api.post('/edit', {}, auth); } catch (_) {}
-  logRow({ ts: t3, userId, nowId: userId, endpoint: '/edit', ip, token, label: 'reuse_after_logout' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/edit',
+    data: {},
+    token,
+    userId,
+    ip,
+    label: 'reuse_after_logout',
+    abnormal_type: 'reuse_after_logout'
+  });
   await humanDelay('/edit');
 
   // user_id を送らずログイン試行
-  const t4 = new Date().toISOString();
-  try { await api.post('/login', {}, { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } }); } catch (_) {}
-  logRow({ ts: t4, userId: 'unknown', nowId: userId, endpoint: '/login', ip, token: 'none', label: 'missing_user_id' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: {},
+    token: null,
+    userId: 'unknown',
+    ip,
+    label: 'missing_user_id',
+    abnormal_type: 'missing_user_id'
+  });
   await humanDelay('/login');
 
   // 存在しないページへアクセス
-  const t5 = new Date().toISOString();
-  try { await api.get('/admin', auth); } catch (_) {}
-  logRow({ ts: t5, userId, nowId: userId, endpoint: '/admin', ip, token, label: 'invalid_endpoint' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/admin',
+    token,
+    userId,
+    ip,
+    label: 'invalid_endpoint',
+    abnormal_type: 'invalid_endpoint'
+  });
   await humanDelay('/admin');
 }
 

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -13,6 +13,17 @@ const path = require('path');
 const updateOperationLog = require('./update_operation_log');
 const LOG_FILE = path.join(__dirname, 'logs', 'normal_log.csv');
 
+// logging fields (server.js と同一順)
+const FIELDS = [
+  'timestamp','epoch_ms','user_id','session_id','user_role','auth_method','ip',
+  'geo_location','user_agent','device_type','platform','method','endpoint',
+  'use_case','type','target_id','endpoint_group','referrer','api_version',
+  'status_code','response_time_ms','content_length','success','jwt_payload_sub',
+  'jwt_payload_exp','token_reuse_detected','login_state','time_since_login',
+  'actions_in_session','previous_action','next_action_expected','label',
+  'abnormal_type','severity','comment','debug_info'
+];
+
 // ── マッピング（endpoint → use_case/type） ──────────────
 const MAP = {
   '/login':  { use_case: 'Login',       type: 'AUTH'   },
@@ -27,7 +38,7 @@ const MAP = {
 if (!fs.existsSync(path.dirname(LOG_FILE))) fs.mkdirSync(path.dirname(LOG_FILE));
 fs.writeFileSync(
   LOG_FILE,
-  'timestamp,user_id,now_id,endpoint,use_case,type,ip,jwt_payload,label\n'
+  FIELDS.join(',') + '\n'
 );
 
 // ── 共通ユーティリティ ────────────────────────
@@ -72,89 +83,177 @@ function parseArgs() {
   }
   return { total, delay, parallel };
 }
-function extractPayload(token) {
+// セッション管理: token -> { loginTime, actionCount, lastAction }
+const sessions = new Map();
+
+function decodePayload(token) {
   try {
-    const payloadPart = token.split('.')[1];
-    const json = Buffer.from(payloadPart, 'base64url').toString();
-    const obj  = JSON.parse(json);
-    return Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const json = Buffer.from(token.split('.')[1], 'base64url').toString();
+    return JSON.parse(json);
   } catch (_) {
-    return 'invalid';
+    return null;
   }
 }
-function logRow({ ts, userId, nowId, endpoint, ip, token = 'none', label }) {
-  const { use_case = 'unknown', type = 'unknown' } = MAP[endpoint] || {};
-  const line = [
-    ts,
-    userId,
-    nowId,
-    endpoint,
-    use_case,
-    type,
-    ip,
-    extractPayload(token),
-    label
-  ].join(',') + '\n';
+
+function logRow(obj) {
+  const line = FIELDS.map(f => (obj[f] !== undefined ? String(obj[f]) : ''))
+    .join(',') + '\n';
   fs.appendFileSync(LOG_FILE, line);
+}
+
+async function requestAndLog({ method, endpoint, data, token, userId, ip, label }) {
+  const headers = { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const start = Date.now();
+  let res;
+  try {
+    res = await api.request({ method, url: endpoint, data, headers });
+  } catch (err) {
+    res = err.response || { status: 0, headers: {}, data: {} };
+  }
+  const now = Date.now();
+  const session = token ? sessions.get(token) : null;
+  const payload = token ? decodePayload(token) : null;
+  const log = {
+    timestamp: new Date(start).toISOString(),
+    epoch_ms: start,
+    user_id: userId,
+    session_id: token ? token.slice(-8) : 'guest',
+    user_role: '-',
+    auth_method: token ? 'jwt' : 'none',
+    ip,
+    geo_location: '-',
+    user_agent: USER_AGENT,
+    device_type: /mobile/i.test(USER_AGENT) ? 'mobile' : 'pc',
+    platform: process.platform,
+    method: method.toUpperCase(),
+    endpoint,
+    use_case: MAP[endpoint]?.use_case || 'unknown',
+    type: MAP[endpoint]?.type || 'unknown',
+    target_id: data && data.id ? data.id : '',
+    endpoint_group: endpoint.split('/')[1] || '',
+    referrer: '',
+    api_version: ((endpoint.split('/')[1] || '').match(/^v\d+/) || [''])[0],
+    status_code: res.status,
+    response_time_ms: now - start,
+    content_length: res.headers['content-length'] || 0,
+    success: res.status < 400,
+    jwt_payload_sub: payload ? (payload.sub || payload.user_id || '') : '',
+    jwt_payload_exp: payload ? payload.exp || '' : '',
+    token_reuse_detected: '',
+    login_state: token ? 'logged_in' : 'guest',
+    time_since_login: session ? now - session.loginTime : '',
+    actions_in_session: session ? session.actionCount : '',
+    previous_action: session ? session.lastAction : '',
+    next_action_expected: '',
+    label,
+    abnormal_type: '',
+    severity: '',
+    comment: '',
+    debug_info: ''
+  };
+  logRow(log);
+  if (token) {
+    if (!session) {
+      sessions.set(token, { loginTime: start, actionCount: 1, lastAction: MAP[endpoint]?.use_case || endpoint });
+    } else {
+      session.actionCount++;
+      session.lastAction = MAP[endpoint]?.use_case || endpoint;
+    }
+  }
+  if (endpoint === '/login' && res.status < 400 && res.data.token) {
+    return res.data.token;
+  }
+  return token;
 }
 
 // ── 基本操作 ──────────────────────────────────
 async function stepLogin(userId, ip) {
-  const ts = new Date().toISOString();
-  const { data } = await api.post('/login', { user_id: userId }, {
-    headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT }
+  const token = await requestAndLog({
+    method: 'post',
+    endpoint: '/login',
+    data: { user_id: userId },
+    token: null,
+    userId,
+    ip,
+    label: 'normal'
   });
-  const token = data.token;
-  logRow({ ts, userId, nowId: userId, endpoint: '/login', ip, token, label: 'normal' });
   await humanDelay('/login');
-  return { token, auth: {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'X-Forwarded-For': ip,
-      'User-Agent': USER_AGENT
-    }
-  }};
+  return { token, auth: { headers: { Authorization: `Bearer ${token}`, 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } } };
 }
 
 async function stepBrowse(userId, ip, token, auth) {
-  const ts = new Date().toISOString();
-  await api.get('/browse', auth);
-  logRow({ ts, userId, nowId: userId, endpoint: '/browse', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/browse',
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/browse');
 }
 
 async function stepEdit(userId, ip, token, auth) {
-  const ts = new Date().toISOString();
-  await api.post('/edit', {}, auth);
-  logRow({ ts, userId, nowId: userId, endpoint: '/edit', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/edit',
+    data: {},
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/edit');
 }
 
 async function stepLogout(userId, ip, token, auth) {
-  const ts = new Date().toISOString();
-  await api.post('/logout', {}, auth);
-  logRow({ ts, userId, nowId: userId, endpoint: '/logout', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/logout',
+    data: {},
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/logout');
 }
 
 async function stepProfileView(userId, ip, token, auth) {
-  const ts = new Date().toISOString();
-  await api.get('/profile', auth);
-  logRow({ ts, userId, nowId: userId, endpoint: '/profile', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/profile',
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/profile');
 }
 
 async function stepProfileUpdate(userId, ip, token, auth) {
-  const ts = new Date().toISOString();
-  await api.post('/profile', { bio: 'hello' }, auth);
-  logRow({ ts, userId, nowId: userId, endpoint: '/profile', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'post',
+    endpoint: '/profile',
+    data: { bio: 'hello' },
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/profile');
 }
 
 async function stepSearch(userId, ip, token) {
-  const ts = new Date().toISOString();
-  await api.get('/search?q=test', { headers: { 'X-Forwarded-For': ip, 'User-Agent': USER_AGENT } });
-  logRow({ ts, userId, nowId: userId, endpoint: '/search', ip, token, label: 'normal' });
+  await requestAndLog({
+    method: 'get',
+    endpoint: '/search',
+    token,
+    userId,
+    ip,
+    label: 'normal'
+  });
   await humanDelay('/search');
 }
 


### PR DESCRIPTION
## Summary
- include the same extended fields as `server.js` in `normal_logger.js` and `abnormal_logger.js`
- log request details via new `requestAndLog` helper
- generate CSV headers from the unified field list

## Testing
- `npm test` *(fails: process hung)*
- `pytest -q tests/test_sequence_train.py` *(fails: numpy/TensorFlow import error)*
- `node test/cleanup.test.js` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd579da788327a805fccad9fcc377