### PR TITLE
Improve log capture on login

### DIFF
--- a/resource/server.js
+++ b/resource/server.js
@@ -181,6 +181,9 @@ app.post('/login', (req, res) => {
   const payload = { user_id, iat: Date.now() };
   const token   = jwt.sign(payload, SECRET, { expiresIn: '1h' });
   SESSIONS.set(token, { loginTime: Date.now(), actionCount: 0, lastAction: 'LOGIN' });
+  // ログミドルウェアで正しい値を記録するために設定
+  req.user  = payload;
+  req.token = token;
   req.logLabel = 'normal';
   res.json({ token });
 });


### PR DESCRIPTION
## Summary
- ensure login endpoint sets `req.user` and `req.token` so middleware logs all fields
- capture issued JWT in normal_logger and record session info from first request

## Testing
- `npm test` *(fails: process hangs)*
- `pytest -q` *(fails: TensorFlow import error)*

------
https://chatgpt.com/codex/tasks/task_e_686dda4cc46883279dd5ce7b831b72b3