### PR TITLE
Add MATLAB preprocessing script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,3 +59,13 @@ node resource/abnormal_logger.js --n 50 --d 100 --p 4
 |  | `--an` | `100` | 異常系列数 |
 |  | `--ad` | `100` | 異常 delay(ms) |
 
+
+### MATLAB 用前処理
+
+取得したCSVログは `resource/preprocess_log_to_mat.py` で MATLAB 向けの `.mat` ファイルへ変換できます。
+
+```bash
+python resource/preprocess_log_to_mat.py resource/logs/normal_log.csv
+```
+
+`-o` オプションで出力ファイル名を指定可能です。ログをセッション単位の数値系列へ整形し、エンドポイントとメソッドのカテゴリ情報を含めて保存します。

--- a/resource/preprocess_log_to_mat.py
+++ b/resource/preprocess_log_to_mat.py
@@ -1,0 +1,58 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+from scipy.io import savemat
+import ipaddress
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="ログCSVを読み込みMATLAB用の.matファイルに変換します")
+    parser.add_argument("logfile", help="入力CSVファイル")
+    parser.add_argument("-o", "--output", help="出力.matファイル")
+    return parser.parse_args()
+
+
+def preprocess(df):
+    df = df.copy()
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    df = df.sort_values(["session_id", "timestamp"])
+
+    endpoint_codes, endpoint_uniques = pd.factorize(df["endpoint"])
+    df["endpoint_code"] = endpoint_codes
+
+    method_codes, method_uniques = pd.factorize(df["method"])
+    df["method_code"] = method_codes
+
+    def ip_to_int(x):
+        try:
+            return int(ipaddress.ip_address(x))
+        except Exception:
+            return -1
+
+    df["ip_int"] = df["ip"].apply(ip_to_int)
+
+    seq_series = df.groupby("session_id")["endpoint_code"].apply(lambda x: np.array(x, dtype=np.int32))
+    sequences = seq_series.tolist()
+
+    data = {
+        "sequences": np.array(sequences, dtype=object),
+        "endpoint_mapping": {str(k): int(v) for v, k in enumerate(endpoint_uniques)},
+        "method_mapping": {str(k): int(v) for v, k in enumerate(method_uniques)},
+    }
+    return data
+
+
+def main():
+    args = parse_args()
+    output = args.output or os.path.splitext(args.logfile)[0] + ".mat"
+
+    df = pd.read_csv(args.logfile)
+    data = preprocess(df)
+    savemat(output, data)
+    print(f"saved: {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `preprocess_log_to_mat.py` to convert CSV logs to `.mat`
- document MATLAB preprocessing step in `readme.md`

## Testing
- `npm test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e5028fc8327b50f384bdd69ef75